### PR TITLE
:sparkles: Support for smaller resolutions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "flow-8-midi"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bacon",
  "btleplug",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "flow-8-midi"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "bacon",
  "btleplug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,3 @@ bacon = "^2.18.2"
 
 [build-dependencies]
 winresource = "0.1.17"
-bacon = "^2.18.2"
-
-[build-dependencies]
-winresource = "0.1.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flow-8-midi"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 authors = ["Abel Rocha Espinosa <abel.espinosa@alumni.usp.br>"]
 rust-version = "1.85"
@@ -53,6 +53,10 @@ osx_minimum_system_version = "10.11"
 icon = ["./resources/icon_32x32.ico"]
 
 [dev-dependencies]
+bacon = "^2.18.2"
+
+[build-dependencies]
+winresource = "0.1.17"
 bacon = "^2.18.2"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -122,5 +122,6 @@ This creates a GitHub Release with binaries for Linux, Windows, and macOS attach
 * Later, I found [another solution](https://hexler.net/touchosc) for custom control of this unit. Give it a try and use what is best for you!
 
 ## License
+[GNU GENERAL PUBLIC LICENSE - Version 3](./LICENSE)
 
 [GNU GENERAL PUBLIC LICENSE - Version 3](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -122,6 +122,5 @@ This creates a GitHub Release with binaries for Linux, Windows, and macOS attach
 * Later, I found [another solution](https://hexler.net/touchosc) for custom control of this unit. Give it a try and use what is best for you!
 
 ## License
-[GNU GENERAL PUBLIC LICENSE - Version 3](./LICENSE)
 
 [GNU GENERAL PUBLIC LICENSE - Version 3](./LICENSE)

--- a/docs/DEV_MANUAL.md
+++ b/docs/DEV_MANUAL.md
@@ -15,7 +15,8 @@ For general usage, see the **[User Manual](./MANUAL.md)**. For protocol details,
     - [2.1 Debug Build](#21-debug-build)
     - [2.2 Dev-Tools Feature Flag](#22-dev-tools-feature-flag)
     - [2.3 Debug Build (Cross-compilation for Windows)](#23-debug-build-cross-compilation-for-windows)
-    - [2.4 Release Build with Dev-Tools](#24-release-build-with-dev-tools)
+    - [2.4 Simulating Small Screens](#24-simulating-small-screens)
+    - [2.5 Release Build with Dev-Tools](#25-release-build-with-dev-tools)
   - [3. Dev Tools in the UI](#3-dev-tools-in-the-ui)
     - [3.1 Hex Viewer](#31-hex-viewer)
     - [3.2 Copy Hex Dump](#32-copy-hex-dump)
@@ -85,7 +86,26 @@ Then, from PowerShell on the Windows host:
 
 > **Note:** The `gnu` target may require MinGW runtime DLLs. For production Windows binaries, use the `msvc` target compiled natively on Windows or via CI.
 
-### 2.4 Release Build with Dev-Tools
+### 2.4 Simulating Small Screens
+
+Set `FLOW8_SCREEN` to override the detected screen size (format: `WIDTHxHEIGHT`):
+
+```powershell
+$env:FLOW8_SCREEN = "1024x600"
+.\target\x86_64-pc-windows-gnu\release\flow-8-midi.exe
+```
+
+```bash
+FLOW8_SCREEN=1024x600 cargo run
+```
+
+Remove it to restore automatic detection:
+
+```powershell
+Remove-Item Env:FLOW8_SCREEN
+```
+
+### 2.5 Release Build with Dev-Tools
 
 ```bash
 cargo build --release --features dev-tools

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,9 +49,62 @@ fn clipboard_cmd() -> &'static str {
 }
 
 const APPLICATION_NAME: &str = "FLOW 8 MIDI Controller";
-const WINDOW_WIDTH: f32 = 1200.0;
-const WINDOW_HEIGHT: f32 = 700.0;
+const PREFERRED_WIDTH: f32 = 1200.0;
+const PREFERRED_HEIGHT: f32 = 700.0;
+const MIN_WIDTH: f32 = 800.0;
+const MIN_HEIGHT: f32 = 500.0;
 static ICON: &[u8] = include_bytes!("../resources/icon.ico");
+
+fn initial_window_size() -> Size {
+    let (max_w, max_h) = screen_size_override().unwrap_or_else(available_screen_size);
+    Size::new(PREFERRED_WIDTH.min(max_w), PREFERRED_HEIGHT.min(max_h))
+}
+
+fn screen_size_override() -> Option<(f32, f32)> {
+    let val = std::env::var("FLOW8_SCREEN").ok()?;
+    let (w, h) = val.split_once('x')?;
+    Some((w.trim().parse().ok()?, h.trim().parse().ok()?))
+}
+
+#[cfg(target_os = "windows")]
+fn available_screen_size() -> (f32, f32) {
+    #[repr(C)]
+    struct Rect {
+        left: i32,
+        top: i32,
+        right: i32,
+        bottom: i32,
+    }
+
+    #[link(name = "user32")]
+    extern "system" {
+        fn SystemParametersInfoW(action: u32, param: u32, pv: *mut Rect, flags: u32) -> i32;
+        fn GetDpiForSystem() -> u32;
+    }
+
+    const SPI_GETWORKAREA: u32 = 0x0030;
+    let mut rect = Rect { left: 0, top: 0, right: 0, bottom: 0 };
+
+    let ok = unsafe { SystemParametersInfoW(SPI_GETWORKAREA, 0, &mut rect, 0) };
+    if ok != 0 {
+        let dpi = unsafe { GetDpiForSystem() };
+        let scale = if dpi >= 96 { dpi as f32 / 96.0 } else { 1.0 };
+
+        let w = (rect.right - rect.left) as f32 / scale;
+        let h = (rect.bottom - rect.top) as f32 / scale;
+
+        if w > 100.0 && h > 100.0 {
+            return (w - 16.0, h - 40.0);
+        }
+    }
+
+    (PREFERRED_WIDTH, PREFERRED_HEIGHT)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn available_screen_size() -> (f32, f32) {
+    (PREFERRED_WIDTH, PREFERRED_HEIGHT)
+}
 
 fn boot() -> FLOW8Controller {
     logger::init();
@@ -83,7 +136,9 @@ fn main() -> iced::Result {
         .subscription(subscription)
         .antialiasing(true)
         .window(window::Settings {
-            size: Size::new(WINDOW_WIDTH, WINDOW_HEIGHT),
+            size: initial_window_size(),
+            min_size: Some(Size::new(MIN_WIDTH, MIN_HEIGHT)),
+            resizable: true,
             icon: Some(icon),
             position: window::Position::Centered,
             ..Default::default()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly UI sizing changes, but it introduces new Windows `unsafe` FFI calls (DPI/work-area detection) that could cause startup issues on some Windows setups if miscomputed or failing.
> 
> **Overview**
> The app window now adapts its initial size to the available screen/work-area, instead of always starting at `1200x700`, and enforces a minimum size (`800x500`) while allowing resizing.
> 
> On Windows this adds a work-area/DPI aware screen-size probe via `user32` (with a `FLOW8_SCREEN=WIDTHxHEIGHT` env override for testing), and the developer manual documents how to use the override. The crate version is bumped to `1.1.0` (including `Cargo.lock`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1562350823482c006ed2a19ae91fd5424c6cd25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->